### PR TITLE
feat: forgot pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs-modules/mailer": "^1.9.1",
-        "@nestjs/common": "^10.0.0",
+        "@nestjs/common": "^10.2.10",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^1.9.1",
-    "@nestjs/common": "^10.0.0",
+    "@nestjs/common": "^10.2.10",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,4 +30,17 @@ export class AuthController {
   getUserInfo(@Req() req: any) {
     return this.authService.getUserInfo(req.user.email);
   }
+  @Public()
+  @Post('forgot-password')
+  forgotPassword(@Body() { email }: { email: string }) {
+    return this.authService.initiatePasswordReset(email);
+  }
+  @Public()
+  @Post('reset-password/:token')
+  resetPassword(
+    @Param() { token }: { token: string },
+    @Body() { newPassword }: { newPassword: string },
+  ) {
+    return this.authService.resetPassword(token, newPassword);
+  }
 }

--- a/src/dto/user.dto.ts
+++ b/src/dto/user.dto.ts
@@ -21,6 +21,7 @@ export class CreateUserDto extends CredentialsUserDto {
   name: string;
   @IsNotEmpty()
   lastName: string;
+  resetPasswordToken?: string;
 }
 
 export class LoginUserDto extends CredentialsUserDto {}

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -23,4 +23,25 @@ export class MailService {
       console.log(error);
     }
   }
+
+  async sendPasswordResetEmail(
+    email: string,
+    name: string,
+    resetToken: string,
+  ) {
+    try {
+      await this.mailerService.sendMail({
+        to: email,
+        subject: '🔐 Recuperación de Contraseña - HenryJobHub',
+        template: './passwordResetEmail',
+        context: {
+          name,
+          resetToken,
+          emailSupport: process.env.EMAIL_SUPPORT,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
 }

--- a/src/mail/templates/passwordResetEmail.hbs
+++ b/src/mail/templates/passwordResetEmail.hbs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset</title>
+</head>
+<body>
+    <p>Hello {{name}},</p>
+    <p>You have requested to reset your password. Click on the following link to reset it:</p>
+    {{!-- TODO: We should be updating this based on the FE --}}
+    <a href="{{resetToken}}">{{resetToken}}</a>
+    <p>If you didn't request this, please ignore this email.</p>
+    <p>Best regards,<br>HenryJobHub Support</p>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,11 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: 'http://localhost:3000',
+    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'],
+    credentials: true,
+  });
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -28,6 +28,9 @@ export class User extends Document {
 
   @Prop({ default: null })
   validationToken: string;
+
+  @Prop({ default: null })
+  resetPasswordToken: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);


### PR DESCRIPTION
## Descripción

Se agregaron 2 rutas:
- /auth/forgot-password
Envía el mail con el enlace (a definir desde el FE, por ahora envía el token).
Body: email.
- /reset-password/:token
Valida el token y actualiza la nueva contraseña.
Body: newPassword.